### PR TITLE
Use rustler precompiled

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,61 @@ on:
       - 'v*'
 
 jobs:
+  build_release:
+    name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        nif: ["2.15"]
+        job:
+          - { target: aarch64-apple-darwin        , os: macos-11      }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04 , use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-20.04 , use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-11      }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019  }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019  }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , use-cross: true }
+
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
+    - name: Extract project version
+      shell: bash
+      run: |
+        # Get the project version from mix.exs
+        echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: ${{ matrix.job.target }}
+
+    - name: Build the project
+      id: build-crate
+      uses: philss/rustler-precompiled-action@v1.1.4
+      with:
+        project-name: pact_consumer_nif
+        project-version: ${{ env.PROJECT_VERSION }}
+        target: ${{ matrix.job.target }}
+        nif-version: ${{ matrix.nif }}
+        use-cross: ${{ matrix.job.use-cross }}
+        project-dir: "native/pact_consumer_nif"
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          ${{ steps.build-crate.outputs.file-path }}
   publish:
     name: Publish to Hex.pm
     runs-on: ubuntu-latest
+    needs: build_release
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -25,4 +77,3 @@ jobs:
           key: ${{ secrets.HEX_API_KEY }}
           name: pact_consumer_ex
           tag-release: 'false'
-

--- a/lib/builders/message_builder.ex
+++ b/lib/builders/message_builder.ex
@@ -63,7 +63,10 @@ defmodule Pact.Builders.MessageBuilder do
   Specify the body as `JsonPattern`, possibly including special matching
   rules.
   """
-  @spec json_body(builder :: Native.MessageInteractionBuilder.t(), body :: Patterns.json_pattern()) ::
+  @spec json_body(
+          builder :: Native.MessageInteractionBuilder.t(),
+          body :: Patterns.json_pattern()
+        ) ::
           Native.MessageInteractionBuilder.t()
   def json_body(builder, body), do: Native.message_builder_json_body(builder, body)
 

--- a/lib/native/builders/request_builder.ex
+++ b/lib/native/builders/request_builder.ex
@@ -97,11 +97,17 @@ defmodule Pact.Native.Builders.RequestBuilder do
       def request_builder_body2(_builder, _body, _content_type),
         do: :erlang.nif_error(:nif_not_loaded)
 
-      @spec request_builder_json_body(builder :: RequestBuilder.t(), body :: Patterns.json_pattern()) ::
+      @spec request_builder_json_body(
+              builder :: RequestBuilder.t(),
+              body :: Patterns.json_pattern()
+            ) ::
               RequestBuilder.t()
       def request_builder_json_body(_builder, _body), do: :erlang.nif_error(:nif_not_loaded)
 
-      @spec request_builder_body_matching(builder :: RequestBuilder.t(), body :: Patterns.string_pattern()) ::
+      @spec request_builder_body_matching(
+              builder :: RequestBuilder.t(),
+              body :: Patterns.string_pattern()
+            ) ::
               RequestBuilder.t()
       def request_builder_body_matching(_builder, _body), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/lib/native/builders/response_builder.ex
+++ b/lib/native/builders/response_builder.ex
@@ -82,11 +82,17 @@ defmodule Pact.Native.Builders.ResponseBuilder do
       def response_builder_body2(_builder, _body, _content_type),
         do: :erlang.nif_error(:nif_not_loaded)
 
-      @spec response_builder_json_body(builder :: ResponseBuilder.t(), body :: Patterns.json_pattern()) ::
+      @spec response_builder_json_body(
+              builder :: ResponseBuilder.t(),
+              body :: Patterns.json_pattern()
+            ) ::
               ResponseBuilder.t()
       def response_builder_json_body(_builder, _body), do: :erlang.nif_error(:nif_not_loaded)
 
-      @spec response_builder_body_matching(builder :: ResponseBuilder.t(), body :: Patterns.string_pattern()) ::
+      @spec response_builder_body_matching(
+              builder :: ResponseBuilder.t(),
+              body :: Patterns.string_pattern()
+            ) ::
               ResponseBuilder.t()
       def response_builder_body_matching(_builder, _body), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/lib/native/pact_consumer.ex
+++ b/lib/native/pact_consumer.ex
@@ -1,7 +1,12 @@
 defmodule Pact.Native.PactConsumer do
   @moduledoc false
+  version = Mix.Project.config()[:version]
 
-  use Rustler, otp_app: :pact_consumer_ex, crate: "pact_consumer_nif"
+  use RustlerPrecompiled,
+    otp_app: :pact_consumer_ex,
+    crate: "pact_consumer_nif",
+    base_url: "https://github.com/valerio-iachini/pact_consumer_ex/releases/download/v#{version}",
+    version: version
 
   use Pact.Native.Builders.InteractionBuilder
   use Pact.Native.Builders.MessageBuilder

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PactElixir.MixProject do
   def project do
     [
       app: :pact_consumer_ex,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -25,6 +25,7 @@ defmodule PactElixir.MixProject do
         "Cargo.toml",
         "Cargo.lock",
         "mix.exs",
+        "checksum-*.exs",
         "README.md",
         "LICENSE"
       ]
@@ -34,6 +35,7 @@ defmodule PactElixir.MixProject do
   defp deps do
     [
       {:rustler, "~> 0.36.1"},
+      {:rustler_precompiled, "~> 0.8.2"},
       {:jason, "~> 1.4.4"},
       {:httpoison, "~> 2.2.2", only: [:test]},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
This PR updates the library to use Rustler Precompiled instead of Rustler, allowing users to use the library without installing Rust tooling.