### PR TITLE
Split build and release WFs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,63 +1,9 @@
 name: Publish Hex Package
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 jobs:
-  build_release:
-    name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        nif: ["2.15"]
-        job:
-          - { target: aarch64-apple-darwin        , os: macos-latest }
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
-         #- { target: aarch64-unknown-linux-musl  , os: ubuntu-latest , use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
-          - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-latest , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-latest }
-          - { target: x86_64-pc-windows-gnu       , os: windows-latest }
-          - { target: x86_64-pc-windows-msvc      , os: windows-latest }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest }
-          #- { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
-    permissions:
-      contents: write
-    steps:
-    - name: Checkout source code
-      uses: actions/checkout@v3
-
-    - name: Extract project version
-      shell: bash
-      run: |
-        # Get the project version from mix.exs
-        echo "PROJECT_VERSION=$(sed -n 's/^  *version: *\"\(.*\)\".*/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
-
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        target: ${{ matrix.job.target }}
-
-    - name: Build the project
-      id: build-crate
-      uses: philss/rustler-precompiled-action@v1.1.4
-      with:
-        project-name: pact_consumer_nif
-        project-version: ${{ env.PROJECT_VERSION }}
-        target: ${{ matrix.job.target }}
-        nif-version: ${{ matrix.nif }}
-        use-cross: ${{ matrix.job.use-cross }}
-        project-dir: "."
-
-    - name: Publish archives and packages
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          ${{ steps.build-crate.outputs.file-path }}
   publish:
     name: Publish to Hex.pm
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Build precompiled NIFs
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        nif: ["2.15"]
+        job:
+          - { target: aarch64-apple-darwin        , os: macos-latest }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+         #- { target: aarch64-unknown-linux-musl  , os: ubuntu-latest , use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-latest , use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-latest }
+          - { target: x86_64-pc-windows-gnu       , os: windows-latest }
+          - { target: x86_64-pc-windows-msvc      , os: windows-latest }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest }
+          #- { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
+    - name: Extract project version
+      shell: bash
+      run: |
+        # Get the project version from mix.exs
+        echo "PROJECT_VERSION=$(sed -n 's/^  *version: *\"\(.*\)\".*/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: ${{ matrix.job.target }}
+
+    - name: Build the project
+      id: build-crate
+      uses: philss/rustler-precompiled-action@v1.1.4
+      with:
+        project-name: pact_consumer_nif
+        project-version: ${{ env.PROJECT_VERSION }}
+        target: ${{ matrix.job.target }}
+        nif-version: ${{ matrix.nif }}
+        use-cross: ${{ matrix.job.use-cross }}
+        project-dir: "."
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          ${{ steps.build-crate.outputs.file-path }}

--- a/lib/builders/pact_builder.ex
+++ b/lib/builders/pact_builder.ex
@@ -27,8 +27,9 @@ defmodule Pact.Builders.PactBuilder do
           builder :: Native.PactBuilder.t(),
           description :: String.t(),
           interaction_type :: String.t(),
-          build_fn :: (interaction_builder :: Native.InteractionBuilder.t() ->
-                         Native.InteractionBuilder.t())
+          build_fn ::
+            (interaction_builder :: Native.InteractionBuilder.t() ->
+               Native.InteractionBuilder.t())
         ) :: Native.PactBuilder.t()
   def interaction(builder, description, interaction_type, build_fn) do
     interaction = build_fn.(InteractionBuilder.new(description, interaction_type))
@@ -52,8 +53,9 @@ defmodule Pact.Builders.PactBuilder do
   @spec message_interaction(
           builder :: Native.PactBuilder.t(),
           description :: String.t(),
-          build_fn :: (message_interaction_builder :: Native.MessageInteractionBuilder.t() ->
-                         Native.MessageInteractionBuilder.t())
+          build_fn ::
+            (message_interaction_builder :: Native.MessageInteractionBuilder.t() ->
+               Native.MessageInteractionBuilder.t())
         ) :: Native.PactBuilder.t()
   def message_interaction(builder, description, build_fn) do
     interaction = build_fn.(MessageBuilder.new(description))

--- a/lib/native/pact_consumer.ex
+++ b/lib/native/pact_consumer.ex
@@ -5,10 +5,19 @@ defmodule Pact.Native.PactConsumer do
   use RustlerPrecompiled,
     otp_app: :pact_consumer_ex,
     crate: "pact_consumer_nif",
-    base_url:
-      "https://github.com/valerio-iachini/pact_consumer_ex/releases/download/v#{version}",
+    base_url: "https://github.com/valerio-iachini/pact_consumer_ex/releases/download/v#{version}",
     force_build: System.get_env("PACT_CONSUMER_EX_FORCE_BUILD") == "true",
-    version: version
+    version: version,
+    targets: [
+      "aarch64-apple-darwin",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabihf",
+      "riscv64gc-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-pc-windows-gnu",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-linux-gnu"
+    ]
 
   use Pact.Native.Builders.InteractionBuilder
   use Pact.Native.Builders.MessageBuilder


### PR DESCRIPTION
This PR splits the publish CI into two workflows: one for building the Rust NIFs and one for publishing the package on Hex.